### PR TITLE
added field names to lat/long arrays

### DIFF
--- a/DnD/DnD.js
+++ b/DnD/DnD.js
@@ -63,8 +63,8 @@ define([
 
     // Properties to be sent into constructor
     //list of lat and lon field strings
-    latFieldStrings: ['lat', 'latitude', 'y', 'ycenter'],
-    longFieldStrings: ['lon', 'long', 'longitude', 'x', 'xcenter'],
+    latFieldStrings: ['lat', 'latitude', 'y', 'ycenter', 'point_y'],
+    longFieldStrings: ['lon', 'long', 'longitude', 'x', 'xcenter', 'point_x'],
     iconSize: 23,
     showManualAdd: true,
     postCreate: function() {


### PR DESCRIPTION
When using the Add XY Coordinates geoprocessing tool in ArcGIS, the GP tool adds two fields with the default names being Point_X and Point_Y. Having these field names in your widget by default may be useful to others when running scripts in ArcGIS and then using this widget. I forgot to add the new field names in the array manually. The GP tool I am referencing can be found in ArcMap or ArcCatalog (ArcToolBox -> Data Management Tools -> Features - Add XY Coordinates).

I know this is very minor change.....
