### PR TITLE
Update Nearby.js

### DIFF
--- a/Nearby/Nearby.js
+++ b/Nearby/Nearby.js
@@ -93,6 +93,7 @@ define([
         widgetsInTemplate: true,
         templateString: template,
         baseClass: 'gis_NearbyDijit',
+        isMapSRProjected: false,
 
         postCreate: function() {
             this.inherited(arguments);
@@ -300,7 +301,7 @@ define([
                 // what is the distance radius value?
                 this.nearbyArea = new Circle({
                     center: this.pointGraphic.geometry,
-                    geodesic: true,
+                    geodesic: (this.isMapSRProjected) ? false : true,
                     radius: this.nearbyValueInput.get('value'),
                     radiusUnit: Units[this.nearbyModeDistance_options.get('value')]
                 });


### PR DESCRIPTION
If the map's coordinate system is projected, the creating of the buffer circle fails if geodesic = true. The proposed changes allow this setting to be configured in the Nearby widget setting in viewer.js like this:
`nearby: {
            include: true,
            id: 'nearby',
            type: 'titlePane',
            canFloat: true,
            position: 3,
            path: 'gis/dijit/Nearby',
            title: 'Find Nearby',
            options: {
                map: true,
                mapClickMode: true,                
                isMapSRProjected: true                 
            }`

