### PR TITLE
Update README.md

### DIFF
--- a/Nearby/README.md
+++ b/Nearby/README.md
@@ -14,7 +14,8 @@ nearby: {
   open: false,
   options: {
     map: true,
-    mapClickMode: true
+    mapClickMode: true,
+    isMapSRProjected: true //if the map's coordinate system is projected, set it to true; default is false
   }
 }
 ```


### PR DESCRIPTION
Added the isMapSRProjected to configure the type of the buffer circle: geodesic or not. Default is false. If map's coordinate system is projected, set to true to avoid an error when buffer circle is created.