### PR TITLE
Update Nearby.js

### DIFF
--- a/Nearby/Nearby.js
+++ b/Nearby/Nearby.js
@@ -121,10 +121,13 @@ define([
                 if (i !== 0) {
                     if (this.map.getLayer(layerId).layerInfos && this.map.getLayer(layerId).layerInfos.length > 0) {
                         array.forEach(this.map.getLayer(layerId).layerInfos, lang.hitch(this, function(layerInfo, j) {
-                            options.unshift({
-                                value: layerId + ':' + j,
-                                label: layerInfo.name
-                            });
+                            // check to exclude the group layers as they do not contain features
+                            if (!layerInfo.subLayerIds) {
+                                options.unshift({
+                                    value: layerId + ':' + j,
+                                    label: layerInfo.name
+                                });
+                            }
                         }));
                     } else if (this.map.getLayer(layerId).name) {
                         options.unshift({


### PR DESCRIPTION
Check if a map layer is a group layer, and exclude it if it is. Group layers do not contain features and an error is raised and no results are returned.